### PR TITLE
Serve GitHub stats from an S3 snapshot instead of a live token

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+# Secrets must never enter the image — the app reads config from runtime env vars.
+.env
+.env.*
+
+# Not needed at runtime. NOTE: vault/ and .claude/soul.md must NOT be listed
+# here — src/chat.py reads both at startup.
+.git/
+__pycache__/
+*.pyc
+venv/
+.venv/
+data/
+evals/
+tests/
+scripts/
+explore-uv/
+scratch.ipynb

--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,8 @@ dmypy.json
 
 # Additional
 data/
+# local GitHub stats snapshot (uploaded to S3, never committed)
+data/github_stats/
 explore-uv/
 scratch.ipynb
 vault/

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A conversational AI chatbot ("Remy") that answers questions about my professiona
 
 - 🤖 Interactive chat interface for resume-based Q&A
 - 📚 Grounded in a full knowledge-base wiki (`vault/`) loaded into the model's context
-- 🛠️ Native tool calling for live GitHub contribution stats
+- 🛠️ Native tool calling for GitHub contribution stats, served from a periodically refreshed S3 snapshot (no GitHub token in the deployed app)
 - 💾 Prompt caching so the large static context is cheap after the first request
 - 📊 Evaluation framework for testing and improving responses
 - 🚀 FastAPI backend for scalable deployment
@@ -24,9 +24,11 @@ resume-bot/
 ├── apps/               # Application entry points
 │   ├── fastapi_app.py  # FastAPI backend
 │   └── streamlit_app.py# Streamlit frontend
+├── scripts/            # Local-only: collect GitHub stats + upload snapshot to S3
 ├── src/                # Core bot logic
 │   ├── chat.py         # System-prompt assembly + Claude tool-call loop
-│   ├── tools.py        # GitHub stats tools
+│   ├── stats_provider.py # Serves GitHub stats from the S3 snapshot
+│   ├── tools.py        # Live GitHub API client (used only by scripts/)
 │   └── utils.py        # Helper functions
 └── tests/              # Test suite
 ```
@@ -46,10 +48,53 @@ uv sync
 
 3. Set up environment variables in a `.env` file at the repo root:
 ```bash
-ANTHROPIC_API_KEY=sk-ant-...   # required — powers all responses
-GITHUB_TOKEN=ghp_...           # optional — enables the GitHub stats tools
-ANTHROPIC_MODEL=claude-opus-4-8  # optional — defaults to claude-opus-4-8
+ANTHROPIC_API_KEY=sk-ant-...      # required — powers all responses
+ANTHROPIC_MODEL=claude-opus-4-8   # optional — defaults to claude-opus-4-8
+GITHUB_STATS_BUCKET=my-bucket     # optional — enables the GitHub stats tools (S3 snapshot)
+GITHUB_STATS_PREFIX=github-stats/ # optional — S3 key prefix, defaults to github-stats/
+GITHUB_TOKEN=ghp_...              # local only — used by scripts/collect_github_stats.py, never deployed
 ```
+
+AWS credentials for reading the snapshot come from the default boto3 chain (env vars, `~/.aws`, or an IAM role when deployed on AWS).
+
+## GitHub Stats Snapshot (S3)
+
+The deployed app never holds a GitHub token. Stats are precomputed locally
+for fixed lookback windows (7, 30, 90, 365 days), uploaded to a private S3
+bucket, and served from there. Each answer cites the snapshot's as-of date.
+
+### One-time AWS setup
+
+```bash
+aws s3 mb s3://<your-bucket>   # keep it private (default)
+```
+
+Minimal IAM policy for the **deployed app** (read-only):
+
+```json
+{"Version": "2012-10-17", "Statement": [{
+  "Effect": "Allow",
+  "Action": "s3:GetObject",
+  "Resource": "arn:aws:s3:::<your-bucket>/github-stats/*"
+}]}
+```
+
+The identity you upload with locally additionally needs `s3:PutObject` on the
+same resource.
+
+### Refreshing the snapshot
+
+Run locally whenever you want fresher numbers (requires `GITHUB_TOKEN` and a
+read-scoped fine-grained PAT is enough — the scripts only read commits/PRs):
+
+```bash
+uv run python scripts/collect_github_stats.py                  # writes data/github_stats/*.csv (gitignored)
+uv run python scripts/upload_github_stats.py --bucket <bucket> # uploads to s3://<bucket>/github-stats/
+```
+
+The app caches the snapshot in-process — restart or redeploy to pick up a
+refresh. The lookback windows written by the collect script must match
+`GITHUB_LOOKBACK_WINDOWS` in `src/chat.py`.
 
 ## Running the Application Locally
 
@@ -131,7 +176,7 @@ python evaluate.py
 Each user turn is answered by a single Claude (`claude-opus-4-8`) call:
 
 1. **System prompt** — the Remy persona (`.claude/soul.md`) plus the entire `vault/` wiki (excluding `vault/sources/` and `vault/log.md`), assembled at startup and cached with Anthropic prompt caching.
-2. **Tool-call loop** — the GitHub stats tools in `src/tools.py` are exposed as native tool definitions; the model decides when to call them and results are fed back in the same turn.
+2. **Tool-call loop** — the GitHub stats tools are exposed as native tool definitions; the model decides when to call them and results are fed back in the same turn. Results come from the S3 snapshot via `src/stats_provider.py` (see "GitHub Stats Snapshot" above); `src/tools.py` talks to the live GitHub API and is used only by the local collect script.
 3. **Conversation memory** — chat history lives in the client (Streamlit session state, or the `messages` array API clients send), not on the server.
 
 ## Contributing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,14 @@ dependencies = [
     "aiohttp>=3.11.0",
     "nest_asyncio>=1.6.0",
     "anthropic>=0.79.0",
+    "boto3>=1.34.0",
+    "certifi>=2024.2.2",
     "requests>=2.32.0",
     "streamlit>=1.45.0",
     "ipykernel>=6.29.5",
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0.0",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
-aiohttp>=3.11.0
 alembic>=1.15.2
 anthropic>=0.79.0
+boto3>=1.34.0
+certifi>=2024.2.2
 anyio>=4.9.0
 asyncpg>=0.30.0
 contourpy>=1.3.2
@@ -18,7 +19,6 @@ notebook>=7.0.0
 ipykernel>=6.0.0
 kiwisolver>=1.4.8
 matplotlib>=3.10.3
-nest_asyncio>=1.6.0
 numpy>=2.2.5
 orjson>=3.10.16
 ormsgpack>=1.9.1

--- a/scripts/collect_github_stats.py
+++ b/scripts/collect_github_stats.py
@@ -1,0 +1,114 @@
+"""Collect GitHub stats into local CSV snapshots.
+
+Run locally (needs GITHUB_TOKEN in .env). Produces the two CSVs the deployed
+app serves via S3, one row set per precomputed lookback window:
+
+    data/github_stats/github_repo_stats.csv
+    data/github_stats/github_user_stats.csv
+
+The windows written here must match GITHUB_LOOKBACK_WINDOWS in src/chat.py.
+
+Usage:
+    uv run python scripts/collect_github_stats.py [--windows 7 30 90 365] [--out-dir data/github_stats]
+"""
+
+import argparse
+import asyncio
+import csv
+import sys
+from datetime import date
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from src.tools import GitHubStats
+
+REPO_STATS_FILENAME = "github_repo_stats.csv"
+USER_STATS_FILENAME = "github_user_stats.csv"
+
+REPO_STATS_COLUMNS = [
+    "as_of_date", "lookback_days", "category", "repo_name",
+    "commits", "pull_requests", "total_code_changes",
+]
+USER_STATS_COLUMNS = [
+    "as_of_date", "lookback_days", "total_commits", "total_pull_requests",
+]
+
+
+def sum_user_stats(window_rows: list[dict]) -> dict:
+    """Aggregate user totals from the per-repo rows of one window.
+
+    Derived from the same REST data as the repo stats (the GraphQL
+    contributionsCollection API returns zeros for org-private contributions
+    under a fine-grained PAT). Repos can appear in more than one category,
+    so dedupe by repo name before summing.
+    """
+    by_repo = {row["repo_name"]: row for row in window_rows}
+    return {
+        "total_commits": sum(r["commits"] for r in by_repo.values()),
+        "total_pull_requests": sum(r["pull_requests"] for r in by_repo.values()),
+    }
+
+
+async def collect(windows: list[int]) -> tuple[list[dict], list[dict]]:
+    stats = GitHubStats()
+    as_of = date.today().isoformat()
+    categories = [entry["category_name"] for entry in stats.get_repos()]
+
+    repo_rows, user_rows = [], []
+    for window in windows:
+        window_rows = []
+        for category in categories:
+            for repo in await stats.get_repo_stats_async(
+                lookback_days=window, intent_category_name=category
+            ):
+                window_rows.append({
+                    "as_of_date": as_of,
+                    "lookback_days": window,
+                    "category": category,
+                    **repo,
+                })
+        repo_rows.extend(window_rows)
+        user_rows.append({
+            "as_of_date": as_of,
+            "lookback_days": window,
+            **sum_user_stats(window_rows),
+        })
+        print(f"window {window}d: {len(window_rows)} repo rows")
+
+    return repo_rows, user_rows
+
+
+def write_csv(path: Path, columns: list[str], rows: list[dict]) -> None:
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=columns)
+        writer.writeheader()
+        writer.writerows(rows)
+    print(f"wrote {len(rows)} rows -> {path}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--windows", type=int, nargs="+", default=[7, 30, 90, 365])
+    parser.add_argument("--out-dir", type=Path, default=Path("data/github_stats"))
+    args = parser.parse_args()
+
+    repo_rows, user_rows = asyncio.run(collect(args.windows))
+
+    # GitHubStats logs per-repo fetch errors (e.g. 404 for repos the token
+    # can't see) and returns empty lists, so a permissions problem would
+    # otherwise produce an empty-but-"successful" snapshot.
+    if not repo_rows:
+        raise SystemExit(
+            "No repo stats were collected for any window. Check the ERROR "
+            "logs above — this usually means the token can't see the repos "
+            "(pending org approval or repos not granted to the token)."
+        )
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    write_csv(args.out_dir / REPO_STATS_FILENAME, REPO_STATS_COLUMNS, repo_rows)
+    write_csv(args.out_dir / USER_STATS_FILENAME, USER_STATS_COLUMNS, user_rows)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/upload_github_stats.py
+++ b/scripts/upload_github_stats.py
@@ -1,0 +1,54 @@
+"""Upload the local GitHub stats CSVs to S3.
+
+Run locally after scripts/collect_github_stats.py. Uploads to fixed keys
+({prefix}github_repo_stats.csv, {prefix}github_user_stats.csv), overwriting
+in place so the app always reads the latest snapshot at stable keys.
+
+AWS credentials come from the default boto3 chain (env vars, ~/.aws, SSO).
+
+Usage:
+    uv run python scripts/upload_github_stats.py [--bucket <name>] [--prefix github-stats/] [--dir data/github_stats]
+"""
+
+import argparse
+import os
+from pathlib import Path
+
+import boto3
+from dotenv import load_dotenv
+
+CSV_FILENAMES = ["github_repo_stats.csv", "github_user_stats.csv"]
+
+
+def main() -> None:
+    load_dotenv()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bucket", default=os.getenv("GITHUB_STATS_BUCKET"))
+    parser.add_argument("--prefix", default=os.getenv("GITHUB_STATS_PREFIX", "github-stats/"))
+    parser.add_argument("--dir", type=Path, default=Path("data/github_stats"))
+    args = parser.parse_args()
+
+    if not args.bucket:
+        raise SystemExit("No bucket given: pass --bucket or set GITHUB_STATS_BUCKET in .env")
+    prefix = args.prefix if args.prefix.endswith("/") or not args.prefix else args.prefix + "/"
+
+    missing = [name for name in CSV_FILENAMES if not (args.dir / name).is_file()]
+    if missing:
+        raise SystemExit(
+            f"Missing {missing} in {args.dir}/ — run scripts/collect_github_stats.py first."
+        )
+
+    s3 = boto3.client("s3")
+    for name in CSV_FILENAMES:
+        key = f"{prefix}{name}"
+        s3.put_object(
+            Bucket=args.bucket,
+            Key=key,
+            Body=(args.dir / name).read_bytes(),
+            ContentType="text/csv",
+        )
+        print(f"uploaded s3://{args.bucket}/{key}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/chat.py
+++ b/src/chat.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 from anthropic import Anthropic
 
-from src.tools import GitHubStats
+from src.stats_provider import CachedGitHubStats
 
 REPO_ROOT = Path(__file__).parent.parent
 VAULT_DIR = REPO_ROOT / "vault"
@@ -94,26 +94,32 @@ def rebuild_system_prompt() -> str:
 
 
 GITHUB_CATEGORIES = [
-    "ds-lead", "raas", "medical taxonomy", "recommendation models",
-    "smart links", "article tagging",
+    "automango", "raas", "medical taxonomy",
+    "recommendation models", "smart links", "article tagging",
 ]
+
+# Precomputed snapshot windows — must match the --windows used when running
+# scripts/collect_github_stats.py.
+GITHUB_LOOKBACK_WINDOWS = [7, 30, 90, 365]
 
 TOOL_DEFINITIONS = [
     {
         "name": "github_user_stats",
         "description": (
             "Retrieves Eric Washington's overall GitHub statistics (commits, "
-            "pull requests, issues) across all projects for a time period. "
+            "pull requests) across his tracked project repos for a time period. "
             "Call this when the user asks about Eric's overall coding or "
-            "GitHub activity. Always tell the user the lookback period the "
-            "stats cover."
+            "GitHub activity. Stats come from a periodically refreshed "
+            "snapshot; the result includes an as_of_date. Always tell the "
+            "user the lookback period and the as-of date the stats cover."
         ),
         "input_schema": {
             "type": "object",
             "properties": {
                 "lookback_days": {
                     "type": "integer",
-                    "description": "Days to look back (e.g. 7 for a week, 30 for a month). Defaults to 365.",
+                    "enum": GITHUB_LOOKBACK_WINDOWS,
+                    "description": "Days to look back. Only these precomputed windows exist. Defaults to 365.",
                 },
             },
             "required": [],
@@ -125,8 +131,10 @@ TOOL_DEFINITIONS = [
             "Retrieves Eric Washington's GitHub statistics (commits, pull "
             "requests, code changes) for the repositories of a specific "
             "project category. Call this when the user asks about Eric's "
-            "coding activity on a specific project. Always tell the user the "
-            "lookback period the stats cover."
+            "coding activity on a specific project. Stats come from a "
+            "periodically refreshed snapshot; the result includes an "
+            "as_of_date. Always tell the user the lookback period and the "
+            "as-of date the stats cover."
         ),
         "input_schema": {
             "type": "object",
@@ -138,7 +146,8 @@ TOOL_DEFINITIONS = [
                 },
                 "lookback_days": {
                     "type": "integer",
-                    "description": "Days to look back. Defaults to 365.",
+                    "enum": GITHUB_LOOKBACK_WINDOWS,
+                    "description": "Days to look back. Only these precomputed windows exist. Defaults to 365.",
                 },
             },
             "required": ["intent_category_name"],
@@ -154,7 +163,7 @@ def _execute_tool(name: str, arguments: dict) -> tuple[str, bool]:
     gracefully.
     """
     try:
-        stats = GitHubStats()  # lazy: raises here if GITHUB_TOKEN is missing
+        stats = CachedGitHubStats()  # lazy: raises here if GITHUB_STATS_BUCKET is missing
         if name == "github_user_stats":
             result = stats.get_user_stats(**arguments)
         elif name == "github_repo_stats":

--- a/src/stats_provider.py
+++ b/src/stats_provider.py
@@ -1,0 +1,90 @@
+"""Serve GitHub stats from the S3 CSV snapshot instead of the live API.
+
+The deployed app holds no GitHub token: scripts/collect_github_stats.py and
+scripts/upload_github_stats.py produce the snapshot locally, and this module
+reads it back with the same method signatures GitHubStats exposed, so
+src/chat.py's tool dispatch is unchanged.
+"""
+
+import csv
+import io
+import os
+from functools import lru_cache
+
+import boto3
+
+REPO_STATS_KEY = "github_repo_stats.csv"
+USER_STATS_KEY = "github_user_stats.csv"
+
+_USER_INT_COLUMNS = ["lookback_days", "total_commits", "total_pull_requests"]
+_REPO_INT_COLUMNS = ["lookback_days", "commits", "pull_requests", "total_code_changes"]
+
+
+def _fetch_rows(s3, bucket: str, key: str, int_columns: list[str]) -> list[dict]:
+    try:
+        body = s3.get_object(Bucket=bucket, Key=key)["Body"].read().decode("utf-8")
+    except Exception as e:
+        raise RuntimeError(
+            f"GitHub stats snapshot unavailable (s3://{bucket}/{key}): {e}"
+        ) from e
+    rows = list(csv.DictReader(io.StringIO(body)))
+    if not rows:
+        raise RuntimeError(f"GitHub stats snapshot is empty (s3://{bucket}/{key})")
+    for row in rows:
+        for column in int_columns:
+            row[column] = int(row[column])
+    return rows
+
+
+@lru_cache(maxsize=1)
+def _load_stats(bucket: str, prefix: str) -> tuple[tuple[dict, ...], tuple[dict, ...]]:
+    """Fetch and parse both CSVs once per process; failures are not cached."""
+    s3 = boto3.client("s3")
+    user_rows = _fetch_rows(s3, bucket, prefix + USER_STATS_KEY, _USER_INT_COLUMNS)
+    repo_rows = _fetch_rows(s3, bucket, prefix + REPO_STATS_KEY, _REPO_INT_COLUMNS)
+    return tuple(user_rows), tuple(repo_rows)
+
+
+def _nearest_window(available: list[int], requested: int) -> int:
+    # The tool schema enum should prevent unknown values; snap defensively
+    # and report the window actually used rather than failing.
+    return min(available, key=lambda w: abs(w - requested))
+
+
+class CachedGitHubStats:
+    """Drop-in replacement for GitHubStats backed by the S3 snapshot."""
+
+    def __init__(self):
+        self.bucket = os.getenv("GITHUB_STATS_BUCKET")
+        if not self.bucket:
+            raise ValueError(
+                "GITHUB_STATS_BUCKET not set. Point it at the S3 bucket "
+                "holding the stats snapshot (see README)."
+            )
+        self.prefix = os.getenv("GITHUB_STATS_PREFIX", "github-stats/")
+
+    def get_user_stats(self, lookback_days: int = 365) -> dict:
+        user_rows, _ = _load_stats(self.bucket, self.prefix)
+        window = _nearest_window([r["lookback_days"] for r in user_rows], lookback_days)
+        return dict(next(r for r in user_rows if r["lookback_days"] == window))
+
+    def get_repo_stats(self, lookback_days: int = 365, intent_category_name: str = None) -> dict:
+        _, repo_rows = _load_stats(self.bucket, self.prefix)
+        window = _nearest_window(
+            sorted({r["lookback_days"] for r in repo_rows}), lookback_days
+        )
+        return {
+            "as_of_date": repo_rows[0]["as_of_date"],
+            "lookback_days": window,
+            "repos": [
+                {
+                    "repo_name": r["repo_name"],
+                    "commits": r["commits"],
+                    "pull_requests": r["pull_requests"],
+                    "total_code_changes": r["total_code_changes"],
+                }
+                for r in repo_rows
+                if r["lookback_days"] == window
+                and r["category"] == intent_category_name
+            ],
+        }

--- a/src/tools.py
+++ b/src/tools.py
@@ -6,8 +6,11 @@ from typing import Dict, Any, List, Tuple
 from dotenv import load_dotenv
 import logging
 import ssl
+import certifi
 import nest_asyncio
-load_dotenv()
+# override=True: this module only runs locally (collect script), where the
+# repo's .env must beat any stale GITHUB_TOKEN exported by the shell profile.
+load_dotenv(override=True)
 
 # Allow nested event loops where the loop supports patching. Under uvicorn
 # the loop is uvloop, which nest_asyncio can't patch — that's fine, because
@@ -61,25 +64,32 @@ class GitHubStats:
 
     def _create_ssl_session(self) -> aiohttp.ClientSession:
         """Create an aiohttp session with SSL configuration that works on macOS."""
-        # Create SSL context that's more permissive for macOS
-        ssl_context = ssl.create_default_context()
-        ssl_context.check_hostname = False
-        ssl_context.verify_mode = ssl.CERT_NONE
-        
+        # certifi supplies the CA bundle macOS Python installs sometimes lack;
+        # verification stays on so the token can't be intercepted in transit.
+        ssl_context = ssl.create_default_context(cafile=certifi.where())
         connector = aiohttp.TCPConnector(ssl=ssl_context)
         return aiohttp.ClientSession(connector=connector)
 
     def get_repos(self) -> list[dict]:
         """Get repositories dictionary."""
         logging.info("Getting repository mappings")
+        # Only repos granted to the fine-grained GITHUB_TOKEN. Category names
+        # must stay in sync with GITHUB_CATEGORIES in src/chat.py.
         repos_lod = [
-            {"category_name": "ds-lead", "repos": ["dmd-evals-dbx-scratch", "health-assistant-batch-evals", "optum-now-health-assistant-ai-api", 
-                                                   "optum-now-health-assistant-be", "optum-now-health-assistant-ds", "rvo-eval-sdk"]},
-            {"category_name": "raas", "repos": ["raas-admin-console-ds-sidecar",  "optum-now-core-graphql-api", "optum-now-traveler-api-ds-sidecar", "optum-now-traveler-ds-api", "traverler-v3-scratch", "unified-search-vespa-application"]},
-            {"category_name": "medical taxonomy", "repos": ["medical-taxonomy-enrichment-api", "guides-symptoms-preprocess"]},
-            {"category_name": "recommendation models", "repos": ["rvo-sdapi-models", "tfe_databricks_datascience"]},
-            {"category_name": "smart links", "repos": ["healthline-smart-links",  "end_of_section_links"]},
-            {"category_name": "article tagging", "repos": ["healthline-k1-tagging", "healthline-kmeta-tagging", "healthline-smart-links", "healthline-update-text-data", "healthline-write-content-app-data"]}
+            {"category_name": "automango", "repos": ["automango", "tf-aws-automango"]},
+            {"category_name": "raas", "repos": ["raas-admin-console-ds-sidecar", "optum-now-raas-api-ds-sidecar", "raas-sdk",
+                                                "raas-content-processing-lambdas", "dtp-content-processing-lambdas",
+                                                "optum-now-traveler-api-ds-sidecar", "optum-now-traveler-ds-api",
+                                                "traveler-ds-sdk", "traveler-ds-api-classes", "traveler-ltr-model",
+                                                "traverler-v3-scratch", "unified-search-vespa-application",
+                                                "unified-search-graphql-api", "unified-search-article-vespa-loader"]},
+            {"category_name": "medical taxonomy", "repos": ["medical-taxonomy-enrichment-api"]},
+            {"category_name": "recommendation models", "repos": ["rvo-sdapi-models", "tfe_databricks_datascience",
+                                                                 "read-next-rec-model", "read-next-api"]},
+            {"category_name": "smart links", "repos": ["healthline-smart-links", "end_of_section_links",
+                                                       "mario_end_of_section_sessions"]},
+            {"category_name": "article tagging", "repos": ["healthline-kmeta-tagging", "healthline-smart-links",
+                                                           "healthline-update-text-data", "healthline-write-content-app-data"]}
         ]
         logging.info(f"Found {len(repos_lod)} category mappings")
         return repos_lod
@@ -131,15 +141,7 @@ class GitHubStats:
             tasks = []
             for repo_name in repo_names:
                 pulls_url = f'{self.base_url}/repos/{self.org_name}/{repo_name}/pulls'
-                params = {
-                    'state': 'all',
-                    'creator': self.username,
-                    'sort': 'created',
-                    'direction': 'desc',
-                    'since': start_date.isoformat(),
-                    'until': end_date.isoformat()
-                }
-                tasks.append(self._fetch_prs(session, repo_name, pulls_url, params))
+                tasks.append(self._fetch_prs(session, repo_name, pulls_url, start_date, end_date))
             
             results = await asyncio.gather(*tasks, return_exceptions=True)
             
@@ -156,21 +158,52 @@ class GitHubStats:
             
             return prs_dict
 
+    @staticmethod
+    def _parse_github_timestamp(value: str) -> datetime:
+        """Parse GitHub's ISO-8601 UTC timestamps to a naive datetime."""
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).replace(tzinfo=None)
+
     async def _fetch_commits(self, session: aiohttp.ClientSession, repo_name: str, url: str, params: dict) -> List[Dict]:
-        """Fetch commits for a single repository."""
+        """Fetch commits for a single repository (all pages)."""
+        commits = []
         try:
-            async with session.get(url, headers=self.headers, params=params) as response:
-                response.raise_for_status()
-                return await response.json()
+            for page in range(1, 11):  # safety cap: 1000 commits per repo/window
+                page_params = {**params, 'per_page': 100, 'page': page}
+                async with session.get(url, headers=self.headers, params=page_params) as response:
+                    response.raise_for_status()
+                    batch = await response.json()
+                commits.extend(batch)
+                if len(batch) < 100:
+                    break
+            return commits
         except Exception as e:
             raise Exception(f"Failed to fetch commits for {repo_name}: {str(e)}")
 
-    async def _fetch_prs(self, session: aiohttp.ClientSession, repo_name: str, url: str, params: dict) -> List[Dict]:
-        """Fetch PRs for a single repository."""
+    async def _fetch_prs(self, session: aiohttp.ClientSession, repo_name: str, url: str,
+                         start_date: datetime, end_date: datetime) -> List[Dict]:
+        """Fetch PRs authored by the user within the date range.
+
+        The list-pulls endpoint has no creator/since/until filters, so fetch
+        newest-first and filter client-side, stopping once a page dips past
+        the window start.
+        """
+        prs = []
         try:
-            async with session.get(url, headers=self.headers, params=params) as response:
-                response.raise_for_status()
-                return await response.json()
+            for page in range(1, 11):  # safety cap: 1000 PRs per repo
+                params = {'state': 'all', 'sort': 'created', 'direction': 'desc',
+                          'per_page': 100, 'page': page}
+                async with session.get(url, headers=self.headers, params=params) as response:
+                    response.raise_for_status()
+                    batch = await response.json()
+                for pr in batch:
+                    created = self._parse_github_timestamp(pr["created_at"])
+                    if created < start_date:
+                        return prs
+                    if created <= end_date and (pr.get("user") or {}).get("login") == self.username:
+                        prs.append(pr)
+                if len(batch) < 100:
+                    break
+            return prs
         except Exception as e:
             raise Exception(f"Failed to fetch PRs for {repo_name}: {str(e)}")
 

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -78,7 +78,7 @@ def mock_anthropic():
 
 @pytest.fixture
 def mock_github():
-    with patch("src.chat.GitHubStats") as mock_cls:
+    with patch("src.chat.CachedGitHubStats") as mock_cls:
         yield mock_cls
 
 
@@ -105,7 +105,11 @@ def test_tool_use_round_trip(mock_anthropic, mock_github):
         _response([tool_use], stop_reason="tool_use"),
         _response([_text_block("Eric made 12 commits in the last 30 days.")]),
     ]
-    mock_github.return_value.get_user_stats.return_value = {"totalCommitContributions": 12}
+    user_stats = {
+        "as_of_date": "2026-08-22", "lookback_days": 30,
+        "total_commits": 12, "total_pull_requests": 5,
+    }
+    mock_github.return_value.get_user_stats.return_value = user_stats
 
     answer = respond([{"role": "user", "content": "How active is Eric on GitHub?"}])
 
@@ -119,7 +123,7 @@ def test_tool_use_round_trip(mock_anthropic, mock_github):
     assert tool_results[0]["type"] == "tool_result"
     assert tool_results[0]["tool_use_id"] == "toolu_1"
     assert tool_results[0]["is_error"] is False
-    assert json.loads(tool_results[0]["content"]) == {"totalCommitContributions": 12}
+    assert json.loads(tool_results[0]["content"]) == user_stats
 
 
 def test_repo_stats_tool_dispatch(mock_anthropic, mock_github):
@@ -151,7 +155,7 @@ def test_tool_failure_reported_to_model(mock_anthropic, mock_github):
         _response([tool_use], stop_reason="tool_use"),
         _response([_text_block("Stats are unavailable right now.")]),
     ]
-    mock_github.side_effect = ValueError("GitHub token not found")
+    mock_github.side_effect = ValueError("GITHUB_STATS_BUCKET not set")
 
     answer = respond([{"role": "user", "content": "GitHub stats?"}])
 

--- a/tests/test_stats_provider.py
+++ b/tests/test_stats_provider.py
@@ -1,0 +1,105 @@
+import io
+from unittest.mock import patch
+
+import pytest
+
+from src import stats_provider
+from src.stats_provider import CachedGitHubStats
+
+USER_CSV = """as_of_date,lookback_days,total_commits,total_pull_requests
+2026-08-22,30,12,5
+2026-08-22,365,140,52
+"""
+
+REPO_CSV = """as_of_date,lookback_days,category,repo_name,commits,pull_requests,total_code_changes
+2026-08-22,30,raas,optum-now-core-graphql-api,4,2,1250
+2026-08-22,365,raas,optum-now-core-graphql-api,40,21,15000
+2026-08-22,365,ds-lead,rvo-eval-sdk,7,3,900
+"""
+
+
+def _s3_stub(bodies):
+    """Return an object mimicking boto3's s3 client for the given key->csv map."""
+    class Stub:
+        def get_object(self, Bucket, Key):
+            if Key not in bodies:
+                raise RuntimeError(f"NoSuchKey: {Key}")
+            return {"Body": io.BytesIO(bodies[Key].encode("utf-8"))}
+    return Stub()
+
+
+@pytest.fixture(autouse=True)
+def stats_env(monkeypatch):
+    monkeypatch.setenv("GITHUB_STATS_BUCKET", "test-bucket")
+    monkeypatch.delenv("GITHUB_STATS_PREFIX", raising=False)
+    stats_provider._load_stats.cache_clear()
+    yield
+    stats_provider._load_stats.cache_clear()
+
+
+def _patched_client(bodies=None):
+    if bodies is None:
+        bodies = {
+            "github-stats/github_user_stats.csv": USER_CSV,
+            "github-stats/github_repo_stats.csv": REPO_CSV,
+        }
+    return patch("src.stats_provider.boto3.client", return_value=_s3_stub(bodies))
+
+
+def test_missing_bucket_env_raises(monkeypatch):
+    monkeypatch.delenv("GITHUB_STATS_BUCKET", raising=False)
+    with pytest.raises(ValueError, match="GITHUB_STATS_BUCKET"):
+        CachedGitHubStats()
+
+
+def test_user_stats_exact_window():
+    with _patched_client():
+        stats = CachedGitHubStats().get_user_stats(lookback_days=30)
+    assert stats == {
+        "as_of_date": "2026-08-22", "lookback_days": 30,
+        "total_commits": 12, "total_pull_requests": 5,
+    }
+
+
+def test_user_stats_snaps_to_nearest_window():
+    with _patched_client():
+        stats = CachedGitHubStats().get_user_stats(lookback_days=400)
+    assert stats["lookback_days"] == 365
+    assert stats["total_commits"] == 140
+
+
+def test_repo_stats_filters_category_and_window():
+    with _patched_client():
+        result = CachedGitHubStats().get_repo_stats(
+            lookback_days=365, intent_category_name="raas"
+        )
+    assert result["as_of_date"] == "2026-08-22"
+    assert result["lookback_days"] == 365
+    assert result["repos"] == [{
+        "repo_name": "optum-now-core-graphql-api",
+        "commits": 40, "pull_requests": 21, "total_code_changes": 15000,
+    }]
+
+
+def test_repo_stats_unknown_category_returns_empty_repos():
+    with _patched_client():
+        result = CachedGitHubStats().get_repo_stats(
+            lookback_days=30, intent_category_name="not-a-category"
+        )
+    assert result["repos"] == []
+
+
+def test_s3_failure_raises_with_bucket_and_key():
+    with _patched_client(bodies={}):
+        with pytest.raises(RuntimeError, match=r"s3://test-bucket/github-stats/"):
+            CachedGitHubStats().get_user_stats()
+
+
+def test_empty_csv_raises():
+    header_only = USER_CSV.splitlines()[0] + "\n"
+    with _patched_client(bodies={
+        "github-stats/github_user_stats.csv": header_only,
+        "github-stats/github_repo_stats.csv": REPO_CSV,
+    }):
+        with pytest.raises(RuntimeError, match="empty"):
+            CachedGitHubStats().get_user_stats()

--- a/uv.lock
+++ b/uv.lock
@@ -271,6 +271,34 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.43.78"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/55/e026c943f7f1ed6d2f5e6035713f21233bbe9ee975008662dc64ca0d4ced/boto3-1.43.78.tar.gz", hash = "sha256:2fa59116e298171ef59e7600a8be6c01177faef8af4b9a4314b7a57a04009ada", size = 112679, upload-time = "2026-08-21T19:37:36.84Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/55/288b1f0d987e15db0417f5ea43da564bfa042063f508c259eec893134628/boto3-1.43.78-py3-none-any.whl", hash = "sha256:893f06a171469618e17de78dc927aca6e74fcf45a70d2c5918e9ac9919e96cc9", size = 140028, upload-time = "2026-08-21T19:37:35.358Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.78"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/71/490aaa384855bf3b69405ded52ae77a0e5f4eeb2165044fa65466c4d3a73/botocore-1.43.78.tar.gz", hash = "sha256:e8238d22c1e1342025d75d2e33d154a375e7caad0fc67f77d77faa2d82668b94", size = 15982895, upload-time = "2026-08-21T19:37:32.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/5b/b7c5c22767c0e8eb4bb2bd0a972d77bd0be3dd9908e15d4487094a31fa4b/botocore-1.43.78-py3-none-any.whl", hash = "sha256:ddd020493235e264b3bd12606f239a3d3b2dd7cfb1d25a0691061183c290c228", size = 15677214, upload-time = "2026-08-21T19:37:28.894Z" },
+]
+
+[[package]]
 name = "cachetools"
 version = "6.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -718,6 +746,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "ipykernel"
 version = "6.29.5"
 source = { registry = "https://pypi.org/simple" }
@@ -899,6 +936,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d8/b3/2bd02071c5a2430d0b70403a34411fc519c2f227da7b03da9ba6a956f931/jiter-0.10.0-cp314-cp314-win32.whl", hash = "sha256:ac509f7eccca54b2a29daeb516fb95b6f0bd0d0d8084efaf8ed5dfc7b9f0b357", size = 210127, upload-time = "2025-05-18T19:04:38.837Z" },
     { url = "https://files.pythonhosted.org/packages/03/0c/5fe86614ea050c3ecd728ab4035534387cd41e7c1855ef6c031f1ca93e3f/jiter-0.10.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5ed975b83a2b8639356151cef5c0d597c68376fc4922b45d0eb384ac058cfa00", size = 318527, upload-time = "2025-05-18T19:04:40.612Z" },
     { url = "https://files.pythonhosted.org/packages/b3/4a/4175a563579e884192ba6e81725fc0448b042024419be8d83aa8a80a3f44/jiter-0.10.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3aa96f2abba33dc77f79b4cf791840230375f9534e5fac927ccceb58c5e604a5", size = 354213, upload-time = "2025-05-18T19:04:41.894Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -1502,6 +1548,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "prompt-toolkit"
 version = "3.0.51"
 source = { registry = "https://pypi.org/simple" }
@@ -1876,6 +1931,24 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -2020,6 +2093,8 @@ source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "anthropic" },
+    { name = "boto3" },
+    { name = "certifi" },
     { name = "fastapi" },
     { name = "ipykernel" },
     { name = "nest-asyncio" },
@@ -2030,10 +2105,17 @@ dependencies = [
     { name = "uvicorn" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.11.0" },
     { name = "anthropic", specifier = ">=0.79.0" },
+    { name = "boto3", specifier = ">=1.34.0" },
+    { name = "certifi", specifier = ">=2024.2.2" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "ipykernel", specifier = ">=6.29.5" },
     { name = "nest-asyncio", specifier = ">=1.6.0" },
@@ -2043,6 +2125,9 @@ requires-dist = [
     { name = "streamlit", specifier = ">=1.45.0" },
     { name = "uvicorn", specifier = ">=0.30.0" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8.0.0" }]
 
 [[package]]
 name = "rpds-py"
@@ -2171,6 +2256,18 @@ wheels = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/43/35e4d8aa320bffe8287fe8f65f578fa2d2db0a64212f0e710dce58267854/s3transfer-0.19.2.tar.gz", hash = "sha256:ba0309fd86be3c27dbf78cdd813c13c5e1df16e5874b99d2535ebbdfb9892993", size = 165592, upload-time = "2026-07-22T19:30:44.432Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl", hash = "sha256:d8168eccca828cbb2cd573675333f3bddd254313a9c42494b84c76b539e8ba25", size = 90216, upload-time = "2026-07-22T19:30:43.251Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2269,6 +2366,60 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The deployed app no longer needs a GitHub token. Stats are precomputed locally for fixed lookback windows (7/30/90/365d), uploaded to S3, and read back by a new CachedGitHubStats provider with the same interface, so the tool-call loop is unchanged apart from an enum on lookback_days.

- scripts/collect_github_stats.py: builds the CSV snapshot locally; fails loudly on empty results (e.g. token permission problems)
- scripts/upload_github_stats.py: pushes the CSVs to stable S3 keys
- src/stats_provider.py: fetches + caches the snapshot per process; S3 failures surface through the existing graceful tool-error path
- src/tools.py is now local-script-only; fixed disabled TLS verification (certifi CA bundle instead of CERT_NONE), fixed PR counts (list-pulls ignores creator/since/until, so filter client-side with pagination), paginated commit fetching, and remapped categories to the 28 repos granted to the fine-grained PAT
- user totals are now summed from per-repo data (the GraphQL contributions API returns zeros under a fine-grained PAT)
- .dockerignore keeps .env and other non-runtime files out of the image